### PR TITLE
allow `update()` from `beforeUpdate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Provide the initial state as the first argument. You must not mutate this state 
 
 The second argument is an optional object which can contain the following properties:
 
-- `beforeUpdate`: This is called after the first `update()` call but before the callback. It receives the state as the first argument and you are allowed to update it. You are not allowed to make a call to `update()` from this function.
+- `beforeUpdate`: This is called after the first `update()` call but before the callback. It receives the state as the first argument and you are allowed to update it.
 - `afterUpdate`: This is called after an update occurs after the last subscriber has finished. It receives an object in the first argument with the following:
   - `state:` A `Proxy` to the current state (read-only).
   - `exceptionOccurred`: This is a boolean which is `true` if an exception occured in one or more of the subscribers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -680,9 +680,9 @@
       }
     },
     "@tjenkinson/boundary": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@tjenkinson/boundary/-/boundary-1.2.1.tgz",
-      "integrity": "sha512-YiBMhQK9iZKebUax2bTI0RGRNhOQ475jm+4ZCls4jCr6DQy+Ag23HwyDu7NFEhYxdyx6ktJCU5jRdwTBcQn+Yg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tjenkinson/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-Zq3N32GRAyoTv4IX0OJTwubuwUmEusQEAHHRrgHr5HwEzbqg5EblsZCfjhbdAnDPpIhAWwjTotyattfqV+WDvQ==",
       "dev": true
     },
     "@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-node-resolve": "^8.0.1",
-    "@tjenkinson/boundary": "^1.2.1",
+    "@tjenkinson/boundary": "^2.0.0",
     "@types/jest": "^26.0.0",
     "husky": "^4.2.5",
     "is-plain-object": "^4.1.1",

--- a/src/state-manager-error.ts
+++ b/src/state-manager-error.ts
@@ -1,3 +1,0 @@
-export const CannotUpdateFromBeforeUpdateError = new Error(
-  'update() is not allowed from beforeUpdate().'
-);

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -1,9 +1,7 @@
-import { Boundary, CannotEnterError } from '@tjenkinson/boundary';
-import { CannotUpdateFromBeforeUpdateError } from './state-manager-error';
+import { Boundary } from '@tjenkinson/boundary';
 import { wrap, makeReadonly } from './utils';
 import { ChangeTracker, PropertyPath } from './change-tracker';
 
-export { CannotUpdateFromBeforeUpdateError } from './state-manager-error';
 export { PropertyPath } from './change-tracker';
 
 export type HasChanged = (...propertyPath: PropertyPath) => boolean;
@@ -75,7 +73,6 @@ type ListenerWithChanges<TState> = {
  *
  * There is also a `beforeUpdate` option, which is a callback that will run before any `update()`
  * callbacks are executed, and is allowed to update the state.
- * It is not a allowed to call `update`.
  *
  * @example
  * ```ts
@@ -141,7 +138,7 @@ export class StateManager<TState extends object> {
    * The second argument is an optional object which can contain the following properties:
    * - beforeUpdate: This is called after the first `update()` call but before the callback.
    *                 It receives the state as the first argument and you are allowed to update
-   *                 it. You are not allowed to make a call to `update()` from this function.
+   *                 it.
    * - afterUpdate: This is called after an update occurs after the last subscriber has
    *                finished. It receives an object in the first argument with the following:
    *                - state: A `Proxy` to the current state (read-only).
@@ -293,14 +290,7 @@ export class StateManager<TState extends object> {
 
   private _onEnter(): void {
     if (this._beforeUpdateFn) {
-      try {
-        this._beforeUpdateFn(this._wrappedState);
-      } catch (e) {
-        if (e === CannotEnterError) {
-          throw CannotUpdateFromBeforeUpdateError;
-        }
-        throw e;
-      }
+      this._beforeUpdateFn(this._wrappedState);
     }
   }
 


### PR DESCRIPTION
and fix bug if `beforeUpdate` threw an error (by updating 'boundary')