### PR TITLE
improve `PropertyPath` type

### DIFF
--- a/src/change-tracker.ts
+++ b/src/change-tracker.ts
@@ -1,7 +1,4 @@
-export type PropertyPath = {
-  // at least one item
-  0: PropertyKey;
-} & Array<PropertyKey>;
+export type PropertyPath = [PropertyKey, ...PropertyKey[]];
 
 export class ChangeTracker {
   public static readonly missing: unique symbol = {} as any;


### PR DESCRIPTION
This change means a `PropertyPath` can be passed to `hasChanged` like `hasChanged(...propertyPath)` with no type errors.